### PR TITLE
Fixes a couple errors present on activation

### DIFF
--- a/includes/class-kind-config.php
+++ b/includes/class-kind-config.php
@@ -44,7 +44,7 @@ class Kind_Config {
 	 * @access public
 	 */
 	public static function admin_menu() {
-		add_options_page( '', __( 'Post Kinds', 'Post kind' ), 'manage_options', 'kind_options', array( 'Kind_Config', 'options_form' ) );		
+		add_options_page( '', __( 'Post Kinds', 'Post kind' ), 'manage_options', 'kind_options', array( 'Kind_Config', 'options_form' ) );
 	}
 
 	/**
@@ -111,7 +111,7 @@ class Kind_Config {
 	 * @access public
 	 */
 	public static function termlist_callback() {
-		$options = get_option( 'iwt_options' );
+		$options = get_option( 'iwt_options', array() );
 		$terms = Kind_Taxonomy::get_strings();
 		// Hide these terms until ready for use for now.
 		$hide = array( 'note', 'weather', 'exercise', 'travel', 'rsvp', 'tag', 'follow', 'drink', 'eat' );

--- a/includes/class-kind-taxonomy.php
+++ b/includes/class-kind-taxonomy.php
@@ -176,7 +176,8 @@ class Kind_Taxonomy {
 
 	public static function select_metabox( $post ) {
 		$strings = self::get_strings();
-		$option = get_option( 'iwt_options' );
+		$option = get_option( 'iwt_options', array() );
+		$include = array();
 		if ( array_key_exists( 'termslists', $option ) ) {
 			$include = $option['termslists'];
 		}


### PR DESCRIPTION
Returns an empty array when plugin options (iwt_options) are not yet stored in the database so that there aren't errors with the calls to array_merge and array_key_exists.