### PR TITLE
set post formats synced with post kinds, as intended

### DIFF
--- a/includes/class-kind-plugins.php
+++ b/includes/class-kind-plugins.php
@@ -133,7 +133,7 @@ class Kind_Plugins {
 
 	public static function post_formats( $input, $wp_args ) {
 		$kind = get_post_kind_slug( $wp_args['ID'] );
-		set_post_format( $wp_args['ID'], Kind_Taxonomy::get_kind_info( $kind, 'property' ) );
+		set_post_format( $wp_args['ID'], Kind_Taxonomy::get_kind_info( $kind, 'format' ) );
 	}
 
 } // End Class Kind_Plugins


### PR DESCRIPTION
I noticed the post format was not being set as expected to match the post kind, and when I looked through the code to figure out why I noticed this was using property instead of format.  This fix is working on my own site but hasn't been tested otherwise.