### PR TITLE
Use default_kind setting for posts created via micropub

### DIFF
--- a/includes/class-kind-plugins.php
+++ b/includes/class-kind-plugins.php
@@ -128,7 +128,7 @@ class Kind_Plugins {
 				return;
 			}
 		}
-		set_post_kind( $wp_args['ID'], 'note' );
+		set_post_kind( $wp_args['ID'], get_option( 'kind_default' ) );
 	}
 
 	public static function post_formats( $input, $wp_args ) {


### PR DESCRIPTION
Posts created through micropub were defaulting to note rather than using the set default.