### PR TITLE
Fix kind detection for photo + add video and audio

### DIFF
--- a/includes/class-kind-plugins.php
+++ b/includes/class-kind-plugins.php
@@ -99,7 +99,19 @@ class Kind_Plugins {
 			set_post_kind( $wp_args['ID'], 'like' );
 			return;
 		}
-		if ( isset( $input['properties']['photo'] ) ) {
+
+		// Video & audio come before photo, because either of these could contain a photo
+		if ( isset( $input['properties']['video'] ) || isset( $_FILES['video'] )  ) {
+			set_post_kind( $wp_args['ID'], 'video' );
+			return;
+		}
+
+		if ( isset( $input['properties']['audio'] ) || isset( $_FILES['audio'] )  ) {
+			set_post_kind( $wp_args['ID'], 'audio' );
+			return;
+		}
+
+		if ( isset( $input['properties']['photo'] ) || isset( $_FILES['photo'] )  ) {
 			set_post_kind( $wp_args['ID'], 'photo' );
 			return;
 		}


### PR DESCRIPTION
This fixes kind detection for Micropub posts that are sent as multi-part uploads and also adds video/audio detection.

* Video comes before photo, because videos should
  have a photo, therefore photo will be present
  alongside video

* Audio comes before photo, because audio can have
  a photo, therefore photo could be present
  alongside audio

* Photo last because, if there’s a photo here then
  it’s likely a photo