### PR TITLE
Robust removal of micropub generate_post_content

### DIFF
--- a/includes/class-kind-plugins.php
+++ b/includes/class-kind-plugins.php
@@ -17,8 +17,16 @@ class Kind_Plugins {
 		add_filter( 'semantic_linkbacks_post_type', array( 'Kind_Plugins', 'semantic_post_type' ), 11, 2 );
 
 		// Remove the Automatic Post Generation that the Micropub Plugin Offers
-		remove_filter( 'micropub_post_content', array( 'Micropub_Render', 'generate_post_content' ), 1, 2 );
-		remove_filter( 'micropub_post_content', array( 'Micropub_Plugin', 'generate_post_content' ), 1, 2 );
+		if(class_exists('Micropub_Render')) {
+			if(has_filter('micropub_post_content', array( 'Micropub_Render', 'generate_post_content' ))) {
+				remove_filter( 'micropub_post_content', array( 'Micropub_Render', 'generate_post_content' ), 1, 2 );
+			}
+		}
+		else if(class_exists('Micropub_Plugin')) {
+			if(has_filter('micropub_post_content', array( 'Micropub_Plugin', 'generate_post_content' ))) {
+				remove_filter( 'micropub_post_content', array( 'Micropub_Plugin', 'generate_post_content' ), 1, 2 );
+			}
+		}
 
 	}
 


### PR DESCRIPTION
Only run remove_filters if plugin is active.

Currently running with latest wordpress-micropub on https://igntie.digitalignition.net