### PR TITLE
Update class-kind-taxonomy.php

### DIFF
--- a/includes/class-kind-taxonomy.php
+++ b/includes/class-kind-taxonomy.php
@@ -1216,7 +1216,7 @@ final class Kind_Taxonomy {
 		$name = self::get_kind_info( $kind, 'singular_name' );
 		$svg  = sprintf( '%1$ssvgs/%2$s.svg', plugin_dir_path( __DIR__ ), $kind );
 		if ( file_exists( $svg ) ) {
-			$return = sprintf( '<span class="svg-icon svg-%1$s" style="display: inline; max-width: 1rem; margin: 2px;" aria-hidden="true" aria-label="%2$s" title="%2$s" >%3$s</span>', esc_attr( $kind ), esc_attr( $name ), file_get_contents( $svg ) );
+			$return = sprintf( '<span class="svg-icon svg-%1$s" style="display: inline-block; max-width: 1rem; margin: 2px;" aria-hidden="true" aria-label="%2$s" title="%2$s" >%3$s</span>', esc_attr( $kind ), esc_attr( $name ), file_get_contents( $svg ) );
 		} else {
 			return '';
 		}


### PR DESCRIPTION
You cannot set widths/heights on inline elements.  Therefore this inline style is causing heights/widths to not be set.  In the case of https://github.com/pfefferle/Autonomie this causes the icons to not be sized at all. Removing display: inline or setting to inline-block resolves this.

https://github.com/dshanske/indieweb-post-kinds/commit/ac3d180158ae10222aa34a03bdd45d6f1ff491c1#diff-d54ef2f2d19dfa14a9fc767958af5f08R1164