### PR TITLE
Video: Only cite when there is more than 1 video

### DIFF
--- a/views/kind-video.php
+++ b/views/kind-video.php
@@ -5,7 +5,7 @@
  */
 
 $videos      = $mf2_post->get_videos();
-if ( is_array( $videos )  && (sizeof($videos) > 1)  ) {
+if ( is_array( $videos )  && (count($videos) > 1)  ) {
 	foreach( $videos as $video ) {
 		$video_attachment = new MF2_Post( $video );
 		$cite = $video_attachment->get();

--- a/views/kind-video.php
+++ b/views/kind-video.php
@@ -5,7 +5,7 @@
  */
 
 $videos      = $mf2_post->get_videos();
-if ( is_array( $videos ) ) {
+if ( is_array( $videos )  && (sizeof($videos) > 1)  ) {
 	foreach( $videos as $video ) {
 		$video_attachment = new MF2_Post( $video );
 		$cite = $video_attachment->get();


### PR DESCRIPTION
Sometimes the array is singular (especially after the unique change to parse this)

Also, I'm not 100% on how cite is supposed to work, but in this code, $cite is only ever the result of the last video in the array. That doesn't seem right?