### PR TITLE
Make widget display correctly for singular posts

### DIFF
--- a/includes/class-kind-post-widget.php
+++ b/includes/class-kind-post-widget.php
@@ -52,15 +52,11 @@ class Kind_Post_Widget extends WP_Widget {
 			return;
 		}
 		echo '<div id="kind-posts">';
-		if ( 1 === count( $posts ) ) {
-			printf( '<p>%1$s</p>', self::get_the_link( $post, $kind ) ); // phpcs:ignore
-		} else {
-			echo '<ul>';
-			foreach ( $posts as $post ) {
-				printf( '<li>%1$s</li>', self::get_the_link( $post, $kind ) ); // phpcs:ignore
-			}
-			echo '</ul>';
+		echo '<ul>';
+		foreach ( $posts as $post ) {
+			printf( '<li>%1$s</li>', self::get_the_link( $post, $kind ) ); // phpcs:ignore
 		}
+		echo '</ul>';
 		echo '</div>';
 		// phpcs:ignore
 		if ( isset( $args['after_widget'] ) ) {


### PR DESCRIPTION
Singular posts weren't rendering correctly because inside the first if block condition, `$post` was used, but `$post` is not initialized at that point. Correct variable here would've been `$posts[0]`.

I figured that a singular post should not look any different to 5 posts in this widget, so removed the condition all together. But maybe I'm missing some edge case someone is getting using it like this?