### PR TITLE
Fix PHP Notice in has_post_kind()

### DIFF
--- a/includes/class-kind-taxonomy.php
+++ b/includes/class-kind-taxonomy.php
@@ -1143,7 +1143,7 @@ final class Kind_Taxonomy {
 	 * @return bool True if the post has any of the given kinds (or any kind, if no kind specified), false otherwise.
 	 */
 	public static function has_post_kind( $kinds = array(), $post = null ) {
-		$prefixed = array();
+		$kind = array();
 		if ( $kinds ) {
 			foreach ( (array) $kinds as $single ) {
 				$kind[] = sanitize_key( $single );


### PR DESCRIPTION
I came across a PHP Notice in `has_post_kind()` while experimenting with some theming. It was caused by the `$kind` variable not being initialised before it was passed to `has_term()`. `$prefixed` wasn't being used in the code, so I just renamed that.