### PR TITLE
Remove the diamond on the end of titles

### DIFF
--- a/includes/class-kind-taxonomy.php
+++ b/includes/class-kind-taxonomy.php
@@ -203,7 +203,9 @@ final class Kind_Taxonomy {
 	 */
 	public static function the_title( $title, $post_id ) {
 		if ( ! $title && is_admin() ) {
-			return self::generate_title( $post_id, 60 ) . '&diams;';
+			$titleStr = self::generate_title( $post_id, 60 );
+			if($titleStr == "") { $titleStr = '&diams;'; }
+			return $titleStr;
 		}
 		return $title;
 	}


### PR DESCRIPTION
I'm not sure why this stays around?  I assume it's so there's no 'empty' titles, so I wrote the update with that in mind.