### PR TITLE
Fix conflict with aria-hidden and aria-label on SVG icon wrapper

### DIFF
--- a/includes/class-kind-taxonomy.php
+++ b/includes/class-kind-taxonomy.php
@@ -1125,7 +1125,7 @@ final class Kind_Taxonomy {
 		$name = self::get_kind_info( $kind, 'singular_name' );
 		$svg  = sprintf( '%1$ssvgs/%2$s.svg', plugin_dir_path( __DIR__ ), $kind );
 		if ( file_exists( $svg ) ) {
-			$return = sprintf( '<span class="svg-icon svg-%1$s" style="display: inline-block; max-height: 1rem; margin-right: 0.5rem;" aria-hidden="true" aria-label="%2$s" title="%2$s" >%3$s</span>', esc_attr( $kind ), esc_attr( $name ), file_get_contents( $svg ) );
+			$return = sprintf( '<span class="svg-icon svg-%1$s" style="display: inline-block; max-height: 1rem; margin-right: 0.5rem;" aria-label="%2$s" title="%2$s" ><span aria-hidden="true">%3$s</span></span>', esc_attr( $kind ), esc_attr( $name ), file_get_contents( $svg ) );
 		} else {
 			return '';
 		}


### PR DESCRIPTION
I am not an accessibility expert, but I think when `aria-hidden="true"` is added to an element, that will also hide an `aria-label`. Because of that, I moved the `aria-hidden` to a child element of `.svg-icon`. Another option would be to add it to all `svg` elements, but then one would need to remember that when adding new icons.