### PR TITLE
As per #300 adds an option to pre the title with the post kind

### DIFF
--- a/includes/class-kind-config.php
+++ b/includes/class-kind-config.php
@@ -66,6 +66,13 @@ class Kind_Config {
 			'default'      => str_replace( '},"', "},\r\n\"", wp_json_encode( wp_kses_allowed_html( 'post' ), 128 ) ),
 		);
 		register_setting( 'iwt_options', 'kind_kses', $args );
+		$args = array(
+			'type'         => 'boolean',
+			'description'  => 'Automatically add the Kind to the Title',
+			'show_in_rest' => false,
+			'default'      => 0,
+		);
+		register_setting( 'iwt_options', 'kind_title', $args );
 	}
 
 	/**
@@ -152,6 +159,16 @@ class Kind_Config {
 				)
 			);
 		}
+		add_settings_field(
+			'title',
+			__( 'Automatically add the Kind to the Title', 'indieweb-post-kinds' ),
+			array( static::class, 'checkbox_callback' ),
+			'iwt_options',
+			'iwt-content',
+			array(
+				'name' => 'kind_title',
+			)
+		);
 		// Add Query Var to Admin
 		add_filter( 'query_vars', array( static::class, 'query_var' ) );
 	}
@@ -375,8 +392,8 @@ class Kind_Config {
  							<ul><strong>Other</strong>
  			              				<li><strong>Start Time</strong></li>
  			              				<li><strong>End Time</strong></li>
- 								<li><strong>Duration</strong> - Duration is calculated based on the difference between start and end time. You may just use the time field, 
- 								omitting date and timezone and setting start time to 0:00:00 to set a simple duration.</li> 
+ 								<li><strong>Duration</strong> - Duration is calculated based on the difference between start and end time. You may just use the time field,
+ 								omitting date and timezone and setting start time to 0:00:00 to set a simple duration.</li>
  								<li><strong>RSVP</strong> - For RSVP posts, you can specify whether you are attending, not attending, unsure, or simply interested.</li>
  			            			</ul>
  						',
@@ -387,5 +404,3 @@ class Kind_Config {
 	}
 
 } // End Class
-
-

--- a/includes/class-kind-taxonomy.php
+++ b/includes/class-kind-taxonomy.php
@@ -343,6 +343,10 @@ final class Kind_Taxonomy {
 		if ( ! $title && is_admin() ) {
 			return self::generate_title( $post_id, 60 ) . '&diams;';
 		}
+		$post_kind = get_post_kind($post_id);
+		if(get_option('kind_title') && $post_kind != "" ) {
+			$title = "[".$post_kind."] ".$title;
+		}
 		return $title;
 	}
 
@@ -1319,5 +1323,3 @@ final class Kind_Taxonomy {
 		return $return;
 	}
 } // End Class Kind_Taxonomy
-
-


### PR DESCRIPTION
![](https://puu.sh/HzPy9/f37ed14e55.png)
![](https://puu.sh/HzPyC/0966a4b7d3.png)

While the original blog post in the PR was specific to RSS feeds, the PR title requested the title, so I did that.  We could easily make another checkbox to "only in RSS" and change the behaviour, if that's necessary.