### PR TITLE
Check for 'url' key existence before using

### DIFF
--- a/templates/reply-metabox.php
+++ b/templates/reply-metabox.php
@@ -17,10 +17,12 @@ $attachment = 0;
 
 
 if ( in_array( $kind, array( 'audio', 'video', 'photo' ) ) ) {
-	$attachment = attachment_url_to_postid( $cite['url'] );
-	if ( $attachment ) {
-		$attachment_post = new Kind_Post( $attachment );
-		$cite            = $attachment_post->get_cite();
+	if(array_key_exists('url',$cite)) {
+		$attachment = attachment_url_to_postid( $cite['url'] );
+		if ( $attachment ) {
+			$attachment_post = new Kind_Post( $attachment );
+			$cite            = $attachment_post->get_cite();
+		}
 	}
 }
 


### PR DESCRIPTION
At this moment, there is a situation where cite only has 'name' key and nothing else.

Fixes:
```
Undefined index: url in wp-content/plugins/indieweb-post-kinds/templates/reply-metabox.php on line 20
```